### PR TITLE
V0.3.4 release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,10 +29,7 @@ install:
 
     # Configure the VM.
     # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
-    - cmd: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
-    - cmd: conda.exe config --add channels conda-forge
-    - cmd: conda.exe install scikit-build
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build scikit-build
 
 # Skip .NET project specific build phase.
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,41 @@
+# -*- mode: yaml -*-
+
+environment:
+
+  matrix:
+    - CONFIG: win_c_compilervs2015python3.6
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_c_compilervs2015python3.7
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+
+# We always use a 64-bit machine, but can build x86 distributions
+# with the TARGET_ARCH variable.
+platform:
+    - x64
+
+install:
+    # If there is a newer build queued for the same PR, cancel this one.
+
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    - cmd: rmdir C:\cygwin /s /q
+
+    # Add path, activate `conda` and update conda.
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda.exe update --yes --quiet conda
+
+    - cmd: set PYTHONUNBUFFERED=1
+
+    # Configure the VM.
+    # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+    - cmd: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
+    - cmd: conda.exe config --add channels conda-forge
+    - cmd: conda.exe install scikit-build
+
+# Skip .NET project specific build phase.
+build: off
+
+test_script:
+    - conda.exe build conda-recipe

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,7 @@ install:
 
     # Configure the VM.
     # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
+    - cmd: conda.exe config --add channels conda-forge
     - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build scikit-build
 
 # Skip .NET project specific build phase.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,10 +30,10 @@ install:
     # Configure the VM.
     # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
     - cmd: conda.exe config --add channels conda-forge
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build scikit-build
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda.exe build conda-recipe
+    - conda.exe build conda-recipe-openblas

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,10 @@ include CREDITS
 include gpl-2.0.txt
 include README.rst
 include MANIFEST.in
+include CMakeLists.txt
+include slycot/CMakeLists.txt
+include slycot/tests/CMakeLists.txt
+include slycot/*.py
+include slycot/version.py.in
+include slycot/src/*.f
+include slycot/tests/*.py

--- a/setup.cfg.in
+++ b/setup.cfg.in
@@ -1,0 +1,6 @@
+[metadata]
+
+name = slycot
+version = @version@
+gitrevision = @gitrevision@
+release = @release@

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ Operating System :: MacOS
 ISRELEASED = False
 # assume a version set by conda, next update with git,
 # otherwise count on default
-VERSION = '0.3.3'
+VERSION = '0.3.4'
 
 # Return the git revision as a string
 def git_version(srcdir=None):

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ def get_version_info(srcdir=None):
         dname = os.getcwd().split(os.sep)[-1]
         import re
 
-        m = re.search(r'^[!-].-([0-9.]*).*$', dname)
+        m = re.search(r'[0-9.]+', dname)
         if m:
             FULLVERSION = m.group()
             GIT_REVISION = ''

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ builtins.__SLYCOT_SETUP__ = True
 
 def get_version_info(srcdir=None):
     global ISRELEASED
+    GIT_CYCLE = 0
     
     # Adding the git rev number needs to be done inside write_version_py(),
     # otherwise the import of slycot.version messes up
@@ -104,10 +105,10 @@ def get_version_info(srcdir=None):
     if os.environ.get('CONDA_BUILD', False):
         FULLVERSION = os.environ.get('PKG_VERSION', '???')
         GIT_REVISION = ''
-        GIT_CYCLE = 0
         ISRELEASED = True
     elif os.path.exists('.git'):
-        FULLVERSION, GIT_REVISION, GIT_CYCLE = git_version(srcdir)        
+        FULLVERSION, GIT_REVISION, GIT_CYCLE = git_version(srcdir)
+        ISRELEASED = (GIT_CYCLE == 0)
     elif os.path.exists('slycot/version.py'):
         # must be a source distribution, use existing version file
         try:
@@ -158,8 +159,7 @@ def check_submodules():
         if line.startswith('-') or line.startswith('+'):
             raise ValueError('Submodule not clean: %s' % line)
 
-from distutils.command.sdist import sdist
-
+from skbuild.command.sdist import sdist
 
 class sdist_checked(sdist):
     """ check submodules on sdist to prevent incomplete tarballs """

--- a/setup.py
+++ b/setup.py
@@ -71,12 +71,12 @@ def git_version(srcdir=None):
     try:
         GIT_VERSION = VERSION
         GIT_REVISION = 'Unknown'
-        CIT_CYCLE = 0
+        GIT_CYCLE = 0
         out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'], srcdir)
         GIT_REVISION = out.strip().decode('ascii')
         out = _minimal_ext_cmd(['git', 'tag'], srcdir)
         GIT_VERSION = out.strip().decode('ascii').split('\n')[-1][1:]
-        out = _minimal_ext_cmd(['git', 'describe', '--tags'], srcdir)
+        out = _minimal_ext_cmd(['git', 'describe', '--tags', '--long'], srcdir)
         GIT_CYCLE = out.strip().decode('ascii').split('-')[1]
     except OSError:
         pass

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ Operating System :: MacOS
 """
 
 # defaults
-ISRELEASED = False
+ISRELEASED = True
 # assume a version set by conda, next update with git,
 # otherwise count on default
 VERSION = 'Unkown'
@@ -136,8 +136,19 @@ def get_version_info(srcdir=None):
         GIT_REVISION = setupcfg['metadata'].get('gitrevision', '')
         return FULLVERSION, GIT_REVISION
     else:
-        FULLVERSION = VERSION
-        GIT_REVISION = "Unknown"
+
+        # try to find a version number from the dir name
+        dname = os.getcwd().split(os.sep)[-1]
+        import re
+
+        m = re.search(r'^[!-].-([0-9.]*).*$', dname)
+        if m:
+            FULLVERSION = m.group()
+            GIT_REVISION = ''
+      
+        else:
+            FULLVERSION = VERSION
+            GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
         FULLVERSION += '.' + str(GIT_CYCLE)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ DOCLINES = __doc__.split("\n")
 import os
 import sys
 import subprocess
-import configparser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 if sys.version_info[:2] < (2, 6) or (3, 0) <= sys.version_info[0:2] < (3, 2):
     raise RuntimeError("Python version 2.6, 2.7 or >= 3.2 required.")


### PR DESCRIPTION
Hi @roryyorke 
This is a re-write of the setup.py that gives a workable "python setup.py sdist"
I am using setup.cfg to record the version extracted from git (or conda, if that is being used). A tarball that has no git or conda version information will fall back to reading the setup.cfg
setup.cfg will also work with newer setuptools to configure the build process (so it could be extended later), but in the way I am currently using this, it should not stop an older setuptools (apparently <2016) from working.